### PR TITLE
fix: updated the endpoint to assume the responses live in the 'responses` key of metadata

### DIFF
--- a/girder/api/v1/response.py
+++ b/girder/api/v1/response.py
@@ -175,13 +175,13 @@ class ResponseItem(Resource):
         for key, value in params.items():
             # upload the value (a blob)
             um = UploadModel()
-            filename = "{}.{}".format(key, metadata[key]['type'].split('/')[-1])
-            newUpload = um.uploadFromFile(value.file, metadata[key]['size'],
+            filename = "{}.{}".format(key, metadata['responses'][key]['type'].split('/')[-1])
+            newUpload = um.uploadFromFile(value.file, metadata['responses'][key]['size'],
                                           filename, 'item', newItem, informant,
-                                          metadata[key]['type'])
+                                          metadata['responses'][key]['type'])
 
             # now, replace the metadata key with a link to this upload
-            metadata[key] = newUpload['_id']
+            metadata['responses'][key] = "file::{}".format(newUpload['_id'])
 
 
         if metadata:


### PR DESCRIPTION
I figured out that it was my bad that the activity name wasn't getting set properly. I've reformatted my data to the endpoint from the frontend, now this fix saves the audio files. Oops!