### PR TITLE
pass down exceptions

### DIFF
--- a/girder/api/v1/user.py
+++ b/girder/api/v1/user.py
@@ -265,6 +265,9 @@ class User(Resource):
             otpToken = cherrypy.request.headers.get('Girder-OTP')
             user = self._model.authenticate(login, password, otpToken)
 
+            if type(user) is dict and 'exception' in user:
+                return user;
+
             setCurrentUser(user)
             token = self.sendAuthTokenCookie(user)
 

--- a/girder/models/user.py
+++ b/girder/models/user.py
@@ -203,14 +203,13 @@ class User(AccessControlledModel):
         # This has the same behavior as User.canLogin, but returns more
         # detailed error messages
         if user.get('status', 'enabled') == 'disabled':
-            raise AccessException('Account is disabled.', extra='disabled')
+            return { 'exception' : 'Account is disabled.' }
 
         if self.emailVerificationRequired(user):
-            raise AccessException(
-                'Email verification required.', extra='emailVerification')
+            return { 'exception' : 'Email verification is required.' }
 
         if self.adminApprovalRequired(user):
-            raise AccessException('Account approval required.', extra='accountApproval')
+            return { 'exception' : 'Admin approval required' }
 
         return user
 


### PR DESCRIPTION
Let's pass down these exception messages so that we can tell why a login fails from the app-side.

