### PR TITLE
Abstract Skin and Text to DB

### DIFF
--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -94,7 +94,7 @@ class Context(Resource):
         Description('Get the application skinning information for this server.')
         .param(
             'lang',
-            'Language of skin to get. must follow https://tools.ietf.org/html/bcp47',
+            'Language of skin to get. Must follow <a href="https://tools.ietf.org/html/bcp47">BCP 47</a>.',
             default='@context.@langage',
             required=False
         )

--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -118,6 +118,9 @@ class Context(Resource):
         for s in ['name', 'about']:
             skin[s] = jsonld_expander.getByLanguage(
                 skin[s],
-                lang if lang not in ["@context.@language", ""] else None
+                lang if lang and lang not in [
+                    "@context.@language",
+                    ""
+                ] else None
             )
         return (skin)

--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -116,11 +116,18 @@ class Context(Resource):
             'about': ''
         })
         for s in ['name', 'about']:
-            skin[s] = jsonld_expander.getByLanguage(
+            lookup = jsonld_expander.getByLanguage(
                 skin[s],
                 lang if lang and lang not in [
                     "@context.@language",
                     ""
                 ] else None
+            )
+            skin[s] = lookup if lookup and lookup not in [
+                None,
+                [{}],
+            ] else jsonld_expander.getByLanguage(
+                skin[s],
+                None
             )
         return (skin)

--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -25,6 +25,7 @@ from girder.constants import TokenScope
 from girder.exceptions import ValidationException
 from girder.models.collection import Collection as CollectionModel
 from girder.models.folder import Folder as FolderModel
+from girder.utility import server
 import itertools
 
 
@@ -36,6 +37,7 @@ class Context(Resource):
         self.resourceName = 'context'
         self._model = FolderModel()
         self.route('GET', (), self.getContext)
+        self.route('GET', ('skin',), self.getSkin)
 
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
@@ -54,24 +56,63 @@ class Context(Resource):
         2. Searching with full text search across all folders in the system.
            Simply pass a "text" parameter for this mode.
         """
+        context = FolderModel().findOne({
+            'name': 'JSON-LD',
+            'parentCollection': 'collection',
+            'parentId': CollectionModel().findOne({
+                'name': 'Context'
+            }).get('_id')
+        })
+        if context:
+            return (context.get('meta', {}))
         user = self.getCurrentUser()
-        collections = CollectionModel().find()
-        contextFolder = list(itertools.chain.from_iterable([
-            [
-                folder for folder in FolderModel().childFolders(
-                    parentType='collection',
-                    parent=collection,
-                    user=user,
-                    name="JSON-LD"
-                )
-            ] for collection in [
-                collection for collection in collections if collection[
-                    'name'
-                ] == "Context"
-            ]
-        ]))
-        return (
-            contextFolder[0]['meta'] if (
-                len(contextFolder) and 'meta' in contextFolder[0]
-            ) else contextFolder
+        context = FolderModel().setMetadata(
+            folder=FolderModel().createFolder(
+                parent=CollectionModel().createCollection(
+                    name="Context",
+                    creator=user,
+                    public=True,
+                    reuseExisting=True
+                ),
+                name="JSON-LD",
+                parentType='collection',
+                public=True,
+                creator=user,
+                reuseExisting=True
+            ),
+            metadata={
+                "@context": {
+                    "@language": "en-US",
+                    "@base": server.getApiRoot()
+                }
+            }
         )
+        return (context.get('meta', {}))
+
+    @access.public
+    @autoDescribeRoute(
+        Description('Get the application skinning information for this server.')
+        .param(
+            'lang',
+            'Language of skin to get. must follow https://tools.ietf.org/html/bcp47',
+            default='@context.@langage',
+            required=False
+        )
+    )
+    def getSkin(self):
+        skinFolder = FolderModel().findOne({
+            'name': 'Skin',
+            'parentCollection': 'collection',
+            'parentId': CollectionModel().findOne({
+                'name': 'Context'
+            }).get('_id')
+        })
+        blankSkin = {
+            'name': '',
+            'colors': {
+                'primary': '#000000',
+                'secondary': '#FFFFFF'
+            },
+            'about': ''
+        }
+        return (skinFolder.get('meta', blankSkin))

--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -20,12 +20,12 @@
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource
 from ast import literal_eval
-from girder.api import access
+from girder.api import access, rest
 from girder.constants import TokenScope
 from girder.exceptions import ValidationException
 from girder.models.collection import Collection as CollectionModel
 from girder.models.folder import Folder as FolderModel
-from girder.utility import jsonld_expander, server
+from girder.utility import jsonld_expander
 import itertools
 
 
@@ -83,7 +83,7 @@ class Context(Resource):
             metadata={
                 "@context": {
                     "@language": "en-US",
-                    "@base": server.getApiRoot()
+                    "@base": rest.getApiUrl()
                 }
             }
         )
@@ -95,7 +95,7 @@ class Context(Resource):
         .param(
             'lang',
             'Language of skin to get. Must follow <a href="https://tools.ietf.org/html/bcp47">BCP 47</a>',
-            default='@context.@langage',
+            default='@context.@language',
             required=False
         )
     )

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -191,8 +191,12 @@ class System(Resource):
             'about': ''
         }
         skin = skinFolder.get('meta', blankSkin)
+        ab = getByLanguage(skin.get('about'))
         dSkin = {
-            "about": getByLanguage(skin.get('about')),
+            "about": ab if isinstance(ab, str) else ab.get(
+                '@value',
+                ab.get('@id', '')
+            ) if isinstance(ab, dict) else '',
             "colors": skin.get('colors', blankSkin.get('colors')),
             "name": getByLanguage(skin.get('name'))
         }

--- a/girder/api/v1/system.py
+++ b/girder/api/v1/system.py
@@ -22,10 +22,10 @@ from girder.models.upload import Upload
 from girder.models.user import User
 from girder.settings import SettingKey
 from girder.utility import config, system
+from girder.utility.jsonld_expander import getByLanguage
 from girder.utility.progress import ProgressContext
 from ..describe import Description, autoDescribeRoute
 from ..rest import Resource
-import skin
 
 ModuleStartTime = datetime.datetime.utcnow()
 LOG_BUF_SIZE = 65536
@@ -168,14 +168,35 @@ class System(Resource):
 
     @access.public
     @autoDescribeRoute(
-        Description('Get the application skinning information for this server.')
+        Description(
+            'Get the application skinning information for this server.'
+        )
+        .deprecated()
+        .notes('Use `GET /context/skin`.')
     )
     def getSkin(self):
-        skinDict = {}
-        skinDict['name'] = skin.NAME
-        skinDict['about'] = skin.ABOUT
-        skinDict['colors'] = {'primary': skin.PRIMARY_COLOR, 'secondary': skin.SECONDARY_COLOR}
-        return skinDict
+        skinFolder = Folder().findOne({
+            'name': 'Skin',
+            'parentCollection': 'collection',
+            'parentId': Collection().findOne({
+                'name': 'Context'
+            }).get('_id')
+        })
+        blankSkin = {
+            'name': '',
+            'colors': {
+                'primary': '#000000',
+                'secondary': '#FFFFFF'
+            },
+            'about': ''
+        }
+        skin = skinFolder.get('meta', blankSkin)
+        dSkin = {
+            "about": getByLanguage(skin.get('about')),
+            "colors": skin.get('colors', blankSkin.get('colors')),
+            "name": getByLanguage(skin.get('name'))
+        }
+        return(dSkin)
 
     @access.admin
     @autoDescribeRoute(

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -219,6 +219,55 @@ def getFromLongestMatchingKey(object, listOfKeys, caseInsensitive=True):
         ) if key else None
     )
 
+def getFromLongestMatchingValue(
+    objectList,
+    listOfValues,
+    keyToMatch,
+    caseInsensitive=True
+):
+    """
+    Function to take a list of objects, a list of values and a key to match and
+    return the object with the longest matching value for that key or None if
+    no value matches for that that key.
+
+    :param objectList: The list of objects.
+    :type objectList: list of dicts
+    :param listOfValues: A list of values to try to match
+    :type listOfValues: list of string values
+    :param keyToMatch: key in which to match the value
+    :type keyToMatch: str
+    :param caseInsensitive: Case insensitive value matching?
+    :type caseInsensitive: boolean
+    :returns: dict with longest matching value for specified key in object
+    """
+    objectList = objectList.copy()
+    if caseInsensitive:
+        listOfValues = [k.lower() for k in listOfValues]
+    value = max(
+        [str(k) for k in listOfValues],
+        key=len
+    ) if len(listOfValues) else None
+    if value and value in listOfValues:
+        listOfValues.remove(value)
+    for object in sorted(
+        objectList,
+        key=lambda i: len(i.get(keyToMatch, "")),
+        reverse=True
+    ):
+        if (
+            object.get(keyToMatch, '').lower(
+            ) if caseInsensitive else object.get(keyToMatch, '')
+        )==value:
+            return(object)
+    return(
+        getFromLongestMatchingValue(
+            objectList,
+            listOfValues,
+            keyToMatch,
+            caseInsensitive
+        )
+    )
+
 def getMoreGeneric(langTag):
     """
     Function to return a list of decreasingly specific language tags, given a

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -163,14 +163,12 @@ def getByLanguage(object, tag=None):
         ) if tag else None
     if isinstance(tag, str):
         genLanTag = (tag.split("-") if "-" in tag else [""])[0]
+        tags = [tag.lower(), genLanTag.lower()]
         if isinstance(object, dict):
             genLanKeys = [
                 k for k in object.keys() if (
-                    '-' in k and k.split('-')[0] in [
-                        tag,
-                        genLanTag
-                    ]
-                ) or k in [tag, genLanTag]
+                    '-' in k and k.lower().split('-')[0] in tags
+                ) or k.lower() in tags
             ]
             genLanKey = genLanKeys[0] if len(genLanKeys) else ""
             return(
@@ -192,14 +190,15 @@ def getByLanguage(object, tag=None):
             ]
             if not len(val):
                 val = [
-                    o for o in object if o.get('@language')==(
-                        tag.split("-") if "-" in tag else [""]
+                    o for o in object if o.get('@language').lower()==(
+                        tag.lower().split("-") if "-" in tag else [""]
                     )[0]
                 ]
             if not len(val):
                 val = [
                     o for o in object if (
-                        '-' in o.get('@language') and o.get('@language').split('-')[0] in [
+                        '-' in o.get('@language') and o.get('@language').lower(
+                        ).split('-')[0] in [
                             tag,
                             genLanTag
                         ]

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -171,20 +171,12 @@ def getByLanguage(object, tag=None):
                 getFromLongestMatchingKey(object, tags, caseInsensitive=True)
             )
         if isinstance(object, list):
-            val = [
-                o for o in sorted(
-                    object,
-                    key=lambda i: len(i.get("@language", "")),
-                    reverse=True
-                ) for oKey in getMoreGeneric(
-                    o.get('@language')
-                ) if oKey in [
-                    t.lower() for t in tags
-                ]
-            ]
-            if not len(val):
-                val = [{}]
-            return(val[0].get('@value', val[0]))
+            return([getFromLongestMatchingValue(
+                objectList=object,
+                listOfValues=tags,
+                keyToMatch='@language',
+                caseInsensitive=True
+            )])
     if isinstance(object, str):
         return(object)
 
@@ -259,14 +251,25 @@ def getFromLongestMatchingValue(
             ) if caseInsensitive else object.get(keyToMatch, '')
         )==value:
             return(object)
-    return(
-        getFromLongestMatchingValue(
+    if len(listOfValues)>=1:
+        return(getFromLongestMatchingValue(
             objectList,
             listOfValues,
             keyToMatch,
             caseInsensitive
-        )
-    )
+        ))
+    for object in sorted(
+        objectList,
+        key=lambda i: len(i.get(keyToMatch, "")),
+        reverse=False
+    ):
+        generic = object.get(keyToMatch, '').lower(
+        ) if caseInsensitive else object.get(keyToMatch, '')
+        generic = generic.split('-')[0] if '-' in generic else generic
+        if generic==value:
+            return(object)
+    return({})
+
 
 def getMoreGeneric(langTag):
     """

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -158,7 +158,7 @@ def getByLanguage(object, tag=None):
                 'name': 'Context'
             }).get('_id')
         })
-        tag.get('meta', {}).get('@context', {}).get(
+        tag = tag.get('meta', {}).get('@context', {}).get(
             '@language'
         ) if tag else None
     if isinstance(tag, str):
@@ -207,6 +207,6 @@ def getByLanguage(object, tag=None):
                 ]
             if not len(val):
                 val = [{}]
-            return(val[0].get('@value', {"@id": val[0].get('@id')}))
+            return(val[0].get('@value', val[0]))
     if isinstance(object, str):
         return(object)

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -167,8 +167,9 @@ def getByLanguage(object, tag=None):
         if isinstance(object, dict):
             genLanKeys = [
                 k for k in object.keys() if (
-                    '-' in k and k.lower().split('-')[0] in tags
-                ) or k.lower() in tags
+                    '-' in k.lstrip('@') and k.lstrip('@').lower(
+                    ).split('-')[0] in tags
+                ) or k.lstrip('@').lower() in tags
             ]
             genLanKey = genLanKeys[0] if len(genLanKeys) else ""
             return(
@@ -186,7 +187,7 @@ def getByLanguage(object, tag=None):
             )
         if isinstance(object, list):
             val = [
-                o for o in object if o.get('@language')==tag
+                o for o in object if o.get('@language').lower() in tags
             ]
             if not len(val):
                 val = [
@@ -198,10 +199,7 @@ def getByLanguage(object, tag=None):
                 val = [
                     o for o in object if (
                         '-' in o.get('@language') and o.get('@language').lower(
-                        ).split('-')[0] in [
-                            tag,
-                            genLanTag
-                        ]
+                        ).split('-')[0] in tags
                     )
                 ]
             if not len(val):

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -162,7 +162,6 @@ def getByLanguage(object, tag=None):
         tag = tag.get('meta', {}).get('@context', {}).get(
             '@language'
         ) if tag else None
-    return(tag)
     if isinstance(tag, str):
         genLanTag = (tag.split("-") if "-" in tag else [""])[0]
         tags = [tag.lower(), genLanTag.lower()]

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -172,7 +172,11 @@ def getByLanguage(object, tag=None):
             )
         if isinstance(object, list):
             val = [
-                o for o in object for oKey in getMoreGeneric(
+                o for o in sorted(
+                    object,
+                    key=lambda i: len(i.get("@language", "")),
+                    reverse=True
+                ) for oKey in getMoreGeneric(
                     o.get('@language')
                 ) if oKey in [
                     t.lower() for t in tags

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -172,21 +172,12 @@ def getByLanguage(object, tag=None):
             )
         if isinstance(object, list):
             val = [
-                o for o in object if o.get('@language').lower() in tags
+                o for o in object for oKey in getMoreGeneric(
+                    o.get('@language')
+                ) if oKey in [
+                    t.lower() for t in tags
+                ]
             ]
-            if not len(val):
-                val = [
-                    o for o in object if o.get('@language').lower()==(
-                        tag.lower().split("-") if "-" in tag else [""]
-                    )[0]
-                ]
-            if not len(val):
-                val = [
-                    o for o in object if (
-                        '-' in o.get('@language') and o.get('@language').lower(
-                        ).split('-')[0] in tags
-                    )
-                ]
             if not len(val):
                 val = [{}]
             return(val[0].get('@value', val[0]))

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -141,7 +141,8 @@ def formatLdObject(obj, mesoPrefix='folder', user=None):
 
 def getByLanguage(object, tag=None):
     """
-    Function to get a value or IRI by a language tag following https://tools.ietf.org/html/bcp47.
+    Function to get a value or IRI by a language tag following
+    https://tools.ietf.org/html/bcp47.
 
     :param object: The JSON-LD Object to language-parse
     :type object: dict or list
@@ -161,6 +162,7 @@ def getByLanguage(object, tag=None):
         tag = tag.get('meta', {}).get('@context', {}).get(
             '@language'
         ) if tag else None
+    return(tag)
     if isinstance(tag, str):
         genLanTag = (tag.split("-") if "-" in tag else [""])[0]
         tags = [tag.lower(), genLanTag.lower()]

--- a/skin.py
+++ b/skin.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-
-NAME = 'MindLogger'
-ABOUT = ''
-PRIMARY_COLOR = '#0067A0'
-SECONDARY_COLOR = '#FFFFFF'


### PR DESCRIPTION
- Move skin default from [`skin.py`](https://github.com/ChildMindInstitute/mindlogger-app-backend/blob/eed86699b8fcb05da4218661cc9639e7e1626a7e/skin.py) to Object in database.
- Copy "About" text from [mindlogger-app/app/scenes/AboutApp/index.js](https://github.com/ChildMindInstitute/mindlogger-app/blob/769d08eb32947ee6c38a1d9498de25dea471e2cb/app/scenes/AboutApp/index.js#L61-L96) to a Markdown file [language-tagged](https://tools.ietf.org/html/bcp47) in database.
- Copy application name to a [language-tagged](https://tools.ietf.org/html/bcp47) JSON-LD Object in DB.
- Deprecate `GET /system/skin` in favor of `GET /context/skin` (which returns more JSON-LD than the strings returned by `GET /system/skin`
- When matching language tags, match as specifically as possible, but fall back to a near match, if no match, then to the default if still no match.

Ref #78, #132, https://github.com/ChildMindInstitute/mindlogger-app/issues/77, https://github.com/ChildMindInstitute/mindlogger-app/pull/164
Resolves #134