### PR TITLE
Pass Valid Objects and Exceptions with 200 Instead of Raising 400

### DIFF
--- a/girder/models/model_base.py
+++ b/girder/models/model_base.py
@@ -236,7 +236,10 @@ class Model(object):
                     ] else " {}".format(modelType)
                 )
             )
-        model = loadJSON(url, modelType)
+        try:
+            model = loadJSON(url, modelType)
+        except ValidationException as ve:
+            model = {modelType: {url: ve.message}}
         prefName = self.preferredName(model)
         cachedDoc = self.getCached(url, modelType)
         if cachedDoc:


### PR DESCRIPTION
:pencil: :ambulance: :rocket:

`GET /user/{id}/applets` was returning `400` `Invalid activity URL: /ravlt` for anyone who added the cognitive tasks applet today. Instead, now they'll get a `200` and the Array will include an Object for each exception that includes the `ValidationException` message