### PR TITLE
:tractor: Return String Instead of Filepath for Linked `about` Files

### DIFF
--- a/girder/api/v1/context.py
+++ b/girder/api/v1/context.py
@@ -130,4 +130,8 @@ class Context(Resource):
                 skin[s],
                 None
             )
+            skin[s] = jsonld_expander.fileObjectToStr(skin[s][0]) if isinstance(
+                skin[s],
+                list
+            ) and len(skin[s]) else skin[s]
         return (skin)

--- a/girder/utility/jsonld_expander.py
+++ b/girder/utility/jsonld_expander.py
@@ -80,6 +80,24 @@ def expand(obj, keepUndefined=False):
         return(expanded if bool(expanded) else None)
 
 
+def fileObjectToStr(obj):
+    """
+    Function to load a linked file in a JSON-LD object and return a string.
+
+    :param obj: Object
+    :type obj: dict
+    :returns: String from loaded file
+    """
+    import requests
+    from requests.exceptions import ConnectionError, MissingSchema
+    try:
+        r = requests.get(obj.get('@id'))
+    except (AttributeError, ConnectionError, MissingSchema):
+        r = obj.get("@id") if isinstance(obj, dict) else ""
+        print("Warning: Could not load {}".format(r))
+    return(r.text)
+
+
 def formatLdObject(obj, mesoPrefix='folder', user=None, keepUndefined=False):
     """
     Function to take a compacted JSON-LD Object within a Girder for Mindlogger


### PR DESCRIPTION
Ref ChildMindInstitute/mindlogger-app#211, ChildMindInstitute/mindlogger-app#209, ChildMindInstitute/mindlogger-app#206