### PR TITLE
🚑 Handle schema change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changes
 -------
 Unreleased
 ==========
+2019-10-11: v0.5.3
+^^^^^^^^^^^^^^^^^^
+* Handle change in the way schema are defined per [ReproNim/schema-standardization@`1c54072`](https://github.com/ReproNim/schema-standardization/commit/1c5407247817f2c8ec47f2f286683ad94065e2af)
+
 2019-10-01: v0.5.2
 ^^^^^^^^^^^^^^^^^^
 * Fetch activity responses by URL rather than ID

--- a/girderformindlogger/models/model_base.py
+++ b/girderformindlogger/models/model_base.py
@@ -249,12 +249,9 @@ class Model(object):
                 )
             )
         model = contextualize(loadJSON(url, modelType))
-        atType = model.get('@type', '').split('/')[-1]
-        modelType = firstLower((atType if len(atType) else modelType).split(
-            ":"
-        )[-1])
+        atType = model.get('@type', '').split('/')[-1].split(':')[-1]
+        modelType = firstLower(atType) if len(atType) else modelType
         modelType = 'screen' if modelType.lower()=='field' else modelType
-        print(modelType)
         changedModel = atType != modelType and len(atType)
         prefName = self.preferredName(model)
         cachedDoc = self.getCached(url, modelType)
@@ -281,7 +278,6 @@ class Model(object):
         else:
             cachedId = None
             cachedDocObj = {}
-        print(modelType)
         if not cachedDocObj or len(list(diff(cachedDocObj, model))):
             if cachedId:
                 for prop in provenenceProps:
@@ -345,7 +341,7 @@ class Model(object):
                             }
                         )
                     )
-            return(cachedDoc)
+        return(cachedDoc)
 
 
     def getModelCollection(self, modelType):

--- a/girderformindlogger/models/model_base.py
+++ b/girderformindlogger/models/model_base.py
@@ -250,8 +250,11 @@ class Model(object):
             )
         model = contextualize(loadJSON(url, modelType))
         atType = model.get('@type', '').split('/')[-1]
-        modelType = firstLower(atType) if len(atType) else modelType
+        modelType = firstLower((atType if len(atType) else modelType).split(
+            ":"
+        )[-1])
         modelType = 'screen' if modelType.lower()=='field' else modelType
+        print(modelType)
         changedModel = atType != modelType and len(atType)
         prefName = self.preferredName(model)
         cachedDoc = self.getCached(url, modelType)
@@ -278,7 +281,7 @@ class Model(object):
         else:
             cachedId = None
             cachedDocObj = {}
-
+        print(modelType)
         if not cachedDocObj or len(list(diff(cachedDocObj, model))):
             if cachedId:
                 for prop in provenenceProps:
@@ -342,7 +345,7 @@ class Model(object):
                             }
                         )
                     )
-        return(cachedDoc)
+            return(cachedDoc)
 
 
     def getModelCollection(self, modelType):


### PR DESCRIPTION
[ReproNim/schema-standardization@`1c54072`](https://github.com/ReproNim/schema-standardization/commit/1c5407247817f2c8ec47f2f286683ad94065e2af) (PR [#263](https://github.com/ReproNim/schema-standardization/pull/263)) was a breaking change for how URLs load into MindLogger.

This PR should fix the issue and is already running on both dev and prod ([:bookmark: v0.5.3](https://github.com/ChildMindInstitute/mindlogger-app-backend/releases/tag/v0.5.3)).