### PR TITLE
:ambulance: :speaker: Handle more JSON-LD validatin exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,11 @@ Changes
 -------
 Unreleased
 ==========
-2019-11-01: v0.5.10
+2019-11-06: v0.5.11
+^^^^^^^^^^^^^^^^^^^
+* :ambulance: :speaker: Handle additional JSON-LD errors.
+
+2019-11-04: v0.5.10
 ^^^^^^^^^^^^^^^^^^^
 * :arrow_up: :tractor: :art: `|schema-standardization→reproschema| <https://github.com/ReproNim/reproschema/pull/278>`_
 * :arrow_up: :tractor: :art: `|activitySet→protocol| <https://github.com/ReproNim/reproschema/pull/277>`_

--- a/girderformindlogger/models/__init__.py
+++ b/girderformindlogger/models/__init__.py
@@ -125,23 +125,32 @@ def smartImport(IRI, user=None, refreshCache=False, modelType='activity'):
     from girderformindlogger.utility import firstLower, loadJSON
     from girderformindlogger.utility.jsonld_expander import MODELS, \
         contextualize, reprolibCanonize
+
+    canonical_IRI = reprolibCanonize(IRI)
+    if bool({IRI, canonical_IRI}.intersection({None, "None"})):
+        return((None, None))
     if not refreshCache:
         cachedDoc = MODELS[modelType].findOne({
             '{}.url'.format(modeltype): {
                 '$in': {
                     IRI,
-                    reprolibCanonize(IRI)
+                    canonical_IRI
                 }
             }
         })
         if cachedDoc:
             return((modelType, cachedDoc))
-    print("loading {}".format(reprolibCanonize(IRI)))
-    model = contextualize(loadJSON(reprolibCanonize(IRI)))
+    print("loading {}".format(canonical_IRI))
+    model = contextualize(loadJSON(canonical_IRI))
     atType = model.get('@type', '').split('/')[-1].split(':')[-1]
     modelType = firstLower(atType) if len(atType) else modelType
     modelType = 'screen' if modelType=='field' else modelType
     return((
         modelType,
-        MODELS[modelType].getFromUrl(IRI, modelType, user, refreshCache)
+        MODELS[modelType].getFromUrl(
+            canonical_IRI,
+            modelType,
+            user,
+            refreshCache
+        )
     ))

--- a/girderformindlogger/utility/jsonld_expander.py
+++ b/girderformindlogger/utility/jsonld_expander.py
@@ -169,7 +169,13 @@ def expand(obj, keepUndefined=False):
     try:
         newObj = jsonld.expand(obj)
     except jsonld.JsonLdError as e: # 👮 Catch illegal JSON-LD
-        if e.cause.type == "jsonld.ContextUrlError":
+        if e.type == "jsonld.InvalidUrl":
+            try:
+                newObj = jsonld.expand(reprolibCanonize(obj))
+            except:
+                print("Invalid URL: {}".format(e.details.get("url")))
+                print(obj)
+        elif e.cause.type == "jsonld.ContextUrlError":
             invalidContext = e.cause.details.get("url")
             print("Invalid context: {}".format(invalidContext))
             if invalidContext in obj.get("@context", []):
@@ -536,36 +542,40 @@ def componentImport(obj, protocol, user=None, refreshCache=True):
                     'url' in activity or '@id' in activity
                 ) else (None, None)
                 activityComponent = pluralize(firstLower(
-                    activityComponent.get('@type', [''])[0].split('/')[-1]
-                )) if activityComponent is None else activityComponent
-                activityComponents = (
-                    pluralize(
-                        activityComponent
-                    ) if activityComponent != 'screen' else 'items'
-                )
-                updatedProtocol[activityComponents][
-                    activityContent.get(
-                        'meta',
-                        {}
-                    ).get(
-                        activityComponent,
-                        {}
-                    ).get(
-                        'url',
+                    activityContent.get('@type', [''])[0].split('/')[-1]
+                )) if (activityComponent is None and isinstance(
+                    activityContent,
+                    dict
+                )) else activityComponent
+                if activityComponent is not None:
+                    activityComponents = (
+                        pluralize(
+                            activityComponent
+                        ) if activityComponent != 'screen' else 'items'
+                    )
+                    updatedProtocol[activityComponents][
                         activityContent.get(
                             'meta',
                             {}
                         ).get(
                             activityComponent,
                             {}
-                        ).get('item', '')
-                    )
-                ] = formatLdObject(
-                    activityContent,
-                    activityComponent,
-                    user,
-                    refreshCache=refreshCache
-                ).copy()
+                        ).get(
+                            'url',
+                            activityContent.get(
+                                'meta',
+                                {}
+                            ).get(
+                                activityComponent,
+                                {}
+                            ).get('item', '')
+                        )
+                    ] = formatLdObject(
+                        activityContent,
+                        activityComponent,
+                        user,
+                        refreshCache=refreshCache
+                    ).copy()
         return(_fixUpFormat(deepcopy(updatedProtocol)))
     except:
         import sys, traceback


### PR DESCRIPTION
Resolves https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/41

https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/example/nda-phq has some validation issues that were not handled (eg, [reprolib:voice_task/voice_task_schema](https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/voice_task/voice_task_schema) does not exist).

This PR should handle those exceptions, and e9c9121 is running on [dev](https://dev.mindlogger.org).

There's still some weirdness, eg, [phq9a_5](https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/PHQ-9a/items/phq9a_5) is being keyed as a URLless activity, I think because it's missing a `@type` property, which is no longer implied now that we can nest activities.