### PR TITLE
🚑 Update Invitation Routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changes
 -------
 Unreleased
 ==========
+2019-11-19: v0.6.3
+^^^^^^^^^^^^^^^^^^
+* :hammer: Update invitation routes
+
 2019-11-18: v0.6.1
 ^^^^^^^^^^^^^^^^^^
 * :sparkles: User profiles

--- a/girderformindlogger/api/v1/invitation.py
+++ b/girderformindlogger/api/v1/invitation.py
@@ -190,10 +190,5 @@ class Invitation(Resource):
         """
         Decline an invitation.
         """
-        currentUser = self.getCurrentUser()
-        if currentUser is None:
-            raise AccessException(
-                "You must be logged in to accept an invitation."
-            )
         InvitationModel().remove(invitation)
         return("Successfully deleted invitation.")

--- a/girderformindlogger/api/v1/invitation.py
+++ b/girderformindlogger/api/v1/invitation.py
@@ -39,7 +39,7 @@ class Invitation(Resource):
         self.route('GET', (':id', 'accept'), self.acceptInvitationByToken)
         self.route('POST', (':id', 'accept'), self.acceptInvitation)
         self.route('GET', (':id', 'qr'), self.getQR)
-        self.route('DELETE', (':id', 'remove'), self.declineInvitation)
+        self.route('DELETE', (':id',), self.declineInvitation)
 
     @access.public(scope=TokenScope.USER_INFO_READ)
     @autoDescribeRoute(
@@ -183,7 +183,7 @@ class Invitation(Resource):
         .modelParam(
             'id',
             model=InvitationModel,
-            level=AccessType.WRITE,
+            force=True,
             destName='invitation'
         )
         .errorResponse()
@@ -197,8 +197,4 @@ class Invitation(Resource):
             raise AccessException(
                 "You must be logged in to accept an invitation."
             )
-        if not any([
-            AppletModel().isCoordinator(invitation['appletId'], currentUser)
-        ]):
-            pass
-        return(InvitationModel().htmlInvitation(invitation, currentUser))
+        return(InvitationModel().remove())

--- a/girderformindlogger/api/v1/invitation.py
+++ b/girderformindlogger/api/v1/invitation.py
@@ -56,27 +56,26 @@ class Invitation(Resource):
             required=False,
             dataType='boolean'
         )
+        .param(
+            'includeLink',
+            'Include a link to the invitation on MindLogger web?',
+            required=False,
+            dataType='boolean'
+        )
         .errorResponse()
     )
     @rawResponse
-    def getInvitation(self, invitation, fullHTML=False):
+    def getInvitation(self, invitation, fullHTML=False, includeLink=True):
         """
         Get an invitation as a string.
         """
         currentUser = self.getCurrentUser()
-        if fullHTML:
-            return(InvitationModel().htmlInvitation(
-                invitation,
-                currentUser,
-                fullDoc=fullHTML
-            ))
-        else:
-            return(
-                InvitationModel().htmlInvitation(
-                    invitation,
-                    currentUser
-                )
-            )
+        return(InvitationModel().htmlInvitation(
+            invitation,
+            currentUser,
+            fullDoc=fullHTML,
+            includeLink=includeLink if includeLink is not None else True
+        ))
 
     @access.public(scope=TokenScope.USER_INFO_READ)
     @autoDescribeRoute(

--- a/girderformindlogger/api/v1/invitation.py
+++ b/girderformindlogger/api/v1/invitation.py
@@ -139,8 +139,7 @@ class Invitation(Resource):
             raise AccessException(
                 "You must be logged in to accept an invitation."
             )
-        Invitation().acceptInvitation(invitation, currentUser)
-        return(InvitationModel().htmlInvitation(invitation, currentUser))
+        return(InvitationModel().acceptInvitation(invitation, currentUser))
 
     @access.public(scope=TokenScope.USER_INFO_READ)
     @autoDescribeRoute(
@@ -197,4 +196,5 @@ class Invitation(Resource):
             raise AccessException(
                 "You must be logged in to accept an invitation."
             )
-        return(InvitationModel().remove())
+        InvitationModel().remove(invitation)
+        return("Successfully deleted invitation.")

--- a/girderformindlogger/api/v1/user.py
+++ b/girderformindlogger/api/v1/user.py
@@ -63,6 +63,7 @@ class User(Resource):
     @access.user
     @autoDescribeRoute(
         Description('Get all pending invites for the logged-in user.')
+        .deprecated()
     )
     def getGroupInvites(self):
         pending = self.getCurrentUser().get("groupInvites")

--- a/girderformindlogger/models/invitation.py
+++ b/girderformindlogger/models/invitation.py
@@ -185,28 +185,35 @@ class Invitation(AccessControlledModel):
         from girderformindlogger.utility import context as contextUtil,        \
             mail_utils
 
-        if invitee is not None:
-            try:
-                acceptURL = getApiUrl()
-            except GirderException:
-                import cherrypy
-                from girderformindlogger.utiltiy import config
-
-                acceptURL = "/".join([
-                    cherrypy.url(),
-                    config.getConfig()['server']['api_root']
-                ])
-            acceptURL = "/".join([
-                acceptURL,
-                "invitation",
-                str(invitation['_id']),
-                "accept?token={}".format(str(Token(
-                ).createToken(invitee)['_id']))
-            ])
-            accept = "To accept, click {}".format(acceptURL)
-        else:
-            accept = "To accept, first create an accout or log in, then "      \
-                "reload this invitation."
+        # if invitee is not None:
+            # try:
+            #     acceptURL = getApiUrl()
+            # except GirderException:
+            #     import cherrypy
+            #     from girderformindlogger.utiltiy import config
+            #
+            #     acceptURL = "/".join([
+            #         cherrypy.url(),
+            #         config.getConfig()['server']['api_root']
+            #     ])
+            # acceptURL = "/".join([
+            #     acceptURL,
+            #     "invitation",
+            #     str(invitation['_id']),
+            #     "accept?token={}".format(str(Token(
+            #     ).createToken(invitee)['_id']))
+            # ])
+        acceptURL = "https://web.mindlogger.org/#/invitation/{}".format(str(
+            invitation['_id']
+        ))
+        accept = (
+            "To accept or decline, visit <a href=\"{u}\">{u}</a>".format(
+                u=acceptURL
+            )
+        )
+        # else:
+        #     accept = "To accept, first create an accout or log in, then "      \
+        #         "reload this invitation."
         applet = Applet().load(ObjectId(invitation['appletId']), force=True)
         appletName = Applet().preferredName(applet)
         try:
@@ -288,7 +295,7 @@ class Invitation(AccessControlledModel):
                     reviewers if len(reviewers) else "<ul><li>None</li></ul>"
                 )
         ).strip()
-
+        print(body)
         return(body if not fullDoc else """
 <!DOCTYPE html>
 <html>

--- a/girderformindlogger/models/invitation.py
+++ b/girderformindlogger/models/invitation.py
@@ -175,7 +175,10 @@ class Invitation(AccessControlledModel):
             )
             IDCode().createIdCode(profile, invitation.get('idCode'))
         self.remove(invitation)
-        return(Profile().displayProfileFields(profile, user))
+        return(Profile().displayProfileFields(
+            Profile().load(profile, force=True),
+            user
+        ))
 
     def htmlInvitation(
         self,

--- a/girderformindlogger/models/invitation.py
+++ b/girderformindlogger/models/invitation.py
@@ -164,7 +164,13 @@ class Invitation(AccessControlledModel):
         self.remove(invitation)
         return(profile)
 
-    def htmlInvitation(self, invitation, invitee=None, fullDoc=False):
+    def htmlInvitation(
+        self,
+        invitation,
+        invitee=None,
+        fullDoc=False,
+        includeLink=True
+    ):
         """
         Returns an HTML document rendering the invitation.
 
@@ -203,14 +209,13 @@ class Invitation(AccessControlledModel):
             #     "accept?token={}".format(str(Token(
             #     ).createToken(invitee)['_id']))
             # ])
-        acceptURL = "https://web.mindlogger.org/#/invitation/{}".format(str(
-            invitation['_id']
-        ))
         accept = (
             "To accept or decline, visit <a href=\"{u}\">{u}</a>".format(
-                u=acceptURL
+                u="https://web.mindlogger.org/#/invitation/{}".format(str(
+                    invitation['_id']
+                ))
             )
-        )
+        ) if includeLink else ""
         # else:
         #     accept = "To accept, first create an accout or log in, then "      \
         #         "reload this invitation."
@@ -260,7 +265,7 @@ class Invitation(AccessControlledModel):
 {managers}
 {coordinators}
 <br/>
-{accept}.
+{accept}
         """.format(
             accept=accept,
             appletName=appletName,

--- a/girderformindlogger/models/invitation.py
+++ b/girderformindlogger/models/invitation.py
@@ -175,10 +175,7 @@ class Invitation(AccessControlledModel):
             )
             IDCode().createIdCode(profile, invitation.get('idCode'))
         self.remove(invitation)
-        return(Profile().displayProfileFields(
-            Profile().load(profile, force=True),
-            user
-        ))
+        return(Profile().displayProfileFields(profile, user))
 
     def htmlInvitation(
         self,

--- a/girderformindlogger/models/profile.py
+++ b/girderformindlogger/models/profile.py
@@ -573,7 +573,7 @@ class Profile(AccessControlledModel, dict):
         from .group import Group
 
         user = self._canonicalUser(applet["_id"], user)
-        returnFields=["_id", "coordinatorDefined", "userDefined"]
+        returnFields=["_id", "appletId", "coordinatorDefined", "userDefined"]
         existing = self.findOne(
             {
                 'appletId': applet['_id'],


### PR DESCRIPTION
# Changes
* Updated decline route
  * from `DELETE /invitation/{id}/remove` to just `DELETE /invitation/{id}`
  * any logged in user can now decline (delete) an invitation
* Updated invitation HTML
  * changed link from acceptance to `GET` call to link to invitation on ML-web
  * added `includeLink` param so that link can be excluded when rendered on the web
* Marked `GET user/invites` as deprecated (`GET /applet/{id}/users` includes all open invitations in `pending`)
* Fixed an order-of-operations bug that was causing `POST /invitation/{id}/accept` to fail

Related https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/43