### PR TITLE
:ambulance: :chipmunk: Create cache for new users on first call to GET /user/applets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changes
 -------
 Unreleased
 ==========
+2019-12-17: v0.7.3
+^^^^^^^^^^^^^^^^^^
+* :ambulance: :chipmunk: Resolve caching issue for new users
+
 2019-12-16: v0.7.2
 ^^^^^^^^^^^^^^^^^^
 * :ambulance: Restore `responseDates` to `applet` Objects

--- a/girderformindlogger/api/v1/user.py
+++ b/girderformindlogger/api/v1/user.py
@@ -423,6 +423,8 @@ class User(Resource):
                 reviewer['cached'] = json_util.loads(
                     reviewer['cached']
                 ) if isinstance(reviewer['cached'], str) else reviewer['cached']
+            else:
+                reviewer['cached'] = {}
             if 'applets' in reviewer[
                 'cached'
             ] and role in reviewer['cached']['applets'] and isinstance(
@@ -443,7 +445,6 @@ class User(Resource):
                     active=True,
                     refreshCache=refreshCache
                 )
-
             for applet in applets:
                 try:
                     applet["applet"]["responseDates"] = responseDateList(
@@ -459,7 +460,9 @@ class User(Resource):
 
             return(applets)
         except Exception as e:
-            return(e)
+            import sys, traceback
+            print(sys.exc_info())
+            return([])
 
 
     @access.public(scope=TokenScope.USER_INFO_READ)

--- a/girderformindlogger/api/v1/user.py
+++ b/girderformindlogger/api/v1/user.py
@@ -381,6 +381,7 @@ class User(Resource):
         refreshCache=False
     ):
         import threading
+        from bson import json_util
         from bson.objectid import ObjectId
 
         reviewer = self.getCurrentUser()
@@ -419,9 +420,9 @@ class User(Resource):
             })
         try:
             if 'cached' in reviewer:
-                reviewer['cached'] = jsonld_expander.loadCache(
+                reviewer['cached'] = json_util.loads(
                     reviewer['cached']
-                )
+                ) if isinstance(reviewer['cached'], str) else reviewer['cached']
             if 'applets' in reviewer[
                 'cached'
             ] and role in reviewer['cached']['applets'] and isinstance(

--- a/girderformindlogger/models/applet.py
+++ b/girderformindlogger/models/applet.py
@@ -352,10 +352,14 @@ class Applet(Folder):
 
     def updateUserCache(self, role, user, active=True, refreshCache=False):
         import threading
+        from bson import json_util
         from girderformindlogger.utility import jsonld_expander
 
         applets=self.getAppletsForUser(role, user, active)
-        user['cached'] = jsonld_expander.loadCache(user.get('cached', {}))
+        user['cached'] = user.get('cached', {})
+        user['cached'] = json_util.loads(user['cached']) if isinstance(
+            user['cached'], str
+        ) else user['cached']
         user['cached']['applets'] = user['cached'].get('applets', {})
         user['cached']['applets'][role] = user['cached']['applets'].get(
             role,
@@ -530,7 +534,7 @@ class Applet(Folder):
                     force=True
                 ) if isinstance(user, str) else {}
 
-            if not self.isManager(applet.get('_id', applet), user):
+            if not self.isCoordinator(applet.get('_id', applet), user):
                 return([])
 
             userDict = {

--- a/girderformindlogger/models/profile.py
+++ b/girderformindlogger/models/profile.py
@@ -597,7 +597,6 @@ class Profile(AccessControlledModel, dict):
             } for role in appletGroups.keys()
         }
 
-
         # restructure dictionary & return
         userList = {
             str(ulu["user"]["_id"]): {k: v for k, v in {

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ installReqs = [
     'passlib [bcrypt,totp]',
     'pymongo>=3.6',
     'PyYAML',
-    'psutil',
+    'psutil==5.6.3',
     'pyld>=1.0.4',
     'pyOpenSSL',
     'python-dateutil==2.6.1',


### PR DESCRIPTION
This change is live on [dev](https://dev.mindlogger.org) and should resolve https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/71