### PR TITLE
:lock: :speaker: Plug a security vulnerability and alert users to deprecated endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changes
 -------
 Unreleased
 ==========
+2019-01-17: v0.7.6
+^^^^^^^^^^^^^^^^^^
+* :lock: Stop exposing sensitive data in deprecated `PUT /user/{:id}`
+
 2019-12-18: v0.7.5
 ^^^^^^^^^^^^^^^^^^
 * :racehorse: Check if user requesting user list is a coordinator just once

--- a/girderformindlogger/models/user.py
+++ b/girderformindlogger/models/user.py
@@ -58,6 +58,9 @@ class User(AccessControlledModel):
         """
         Validate the user every time it is stored in the database.
         """
+        for s in ['email', 'displayName', 'firstName']:
+            if s in doc and doc[s] is None:
+                doc[s] = ''
         doc['login'] = doc.get('login', '').lower().strip()
         doc['email'] = doc.get('email', '').lower().strip()
         doc['displayName'] = doc.get(


### PR DESCRIPTION
I would just remove the endpoint, but the mobile app is [still using it](https://github.com/ChildMindInstitute/mindlogger-app/blob/ac4558391236b5bb850125bc1f7bc78369bdc883/app/services/network.js#L141-L156).

Resolves #617
Ref https://github.com/ChildMindInstitute/mindlogger-app-backend/pull/616#discussion_r367973840