### PR TITLE
Parameter Type Change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Changes
 -------
 Unreleased
 ==========
+
+2020-1-28: v0.9.2
+^^^^^^^^^^^^^^^^^^
+* :pencil: Change parameter type for `PUT /user/{id}/code` & `DELETE /user/{id}/code`
+
 2019-12-20: v0.8.1
 ^^^^^^^^^^^^^^^^^^
 * :sparkles: Data access for reviewers

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,5 @@
+.. |masterbranch| replace:: ``master`` branch
+
 *********************
 Girder for MindLogger
 *********************

--- a/girderformindlogger/api/v1/user.py
+++ b/girderformindlogger/api/v1/user.py
@@ -349,8 +349,8 @@ class User(Resource):
 
     @access.public(scope=TokenScope.USER_INFO_READ)
     @autoDescribeRoute(
-        Description('Update a user\'s ID Code.')
-        .param('id', 'Profile ID', required=True)
+        Description('Add a new ID Code to a user.')
+        .param('id', 'Profile ID', required=True, paramType='path')
         .param('code', 'ID code to add to profile', required=True)
         .errorResponse('ID was invalid.')
         .errorResponse('You do not have permission to see this user.', 403)
@@ -378,7 +378,7 @@ class User(Resource):
     @access.public(scope=TokenScope.USER_INFO_READ)
     @autoDescribeRoute(
         Description('Remove an ID Code from a user.')
-        .param('id', 'Profile ID', required=True)
+        .param('id', 'Profile ID', required=True, paramType='path')
         .param(
             'code',
             'ID code to remove from profile. If the ID code to remove is the '


### PR DESCRIPTION
- changes ```id``` in ```PUT /user/{id}/code``` & ```DELETE /user/{id}/code``` from a query parameter to a url parameter
- Fixes #621 