### PR TITLE
Update Invitation html

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changes
 -------
 Unreleased
 ==========
+
+2019-03-30: v0.13.12
+^^^^^^^^^^^^^^^^^^
+Update invitation html
+
+
 2019-03-21: v0.13.11
 fix issue 838: Display name bug for new applets
 

--- a/girderformindlogger/models/invitation.py
+++ b/girderformindlogger/models/invitation.py
@@ -237,7 +237,10 @@ class Invitation(AccessControlledModel):
             )
         ) if includeLink else ""
         applet = Applet().load(ObjectId(invitation['appletId']), force=True)
-        appletName = Applet().preferredName(applet)
+        appletName = applet.get(
+            'displayName',
+            'a new applet'
+        )
         try:
             skin = contextUtil.getSkin()
         except:
@@ -275,9 +278,9 @@ class Invitation(AccessControlledModel):
             Applet().listUsers(applet, 'reviewer', force=True)
         )
         body = """
-{greeting}ou have been invited {byCoordinator}to be {role} of <b>{appletName}</b>{instanceName}.
+{greeting}ou were invited {byCoordinator}to be {role} of <b>{appletName}</b>{instanceName}.
 <br/>
-{description}
+Below are the users that have access to your data:
 {reviewers}
 {managers}
 {coordinators}
@@ -290,21 +293,16 @@ class Invitation(AccessControlledModel):
                 coordinator.get("displayName", "an anonymous entity"),
                 "<a href=\"mailto:{email}\">{email}</a>".format(
                     email=coordinator["email"]
-                ) if "email" in coordinator else "email address unavailable"
+                ) if "email" in coordinator and coordinator["email"] is not None else "email not available"
             ) if isinstance(coordinator, dict) else "",
             coordinators="<h3>Users who can change this applet's settings, "
-                "but not who can access your data: </h3>{}"
+                "but who cannot change who can see your data: </h3>{}"
                 "".format(
                     coordinators if len(
                         coordinators
                     ) else "<ul><li>None</li></ul>"
                 ),
-            description="<h2>Description</h2><p>{}</p>".format(
-                description
-            ) if len(description) else "",
-            greeting="Welcome {}; y".format(
-                displayProfile['displayName']
-            ) if 'displayName' in displayProfile else "Welcome! Y",
+            greeting="Welcome to MindLogger! Y",
             instanceName=" on {}".format(
                 instanceName
             ) if instanceName is not None and len(instanceName) else "",

--- a/girderformindlogger/utility/mail_utils.py
+++ b/girderformindlogger/utility/mail_utils.py
@@ -29,7 +29,7 @@ def formatUserString(u):
     return(
         "{name} {email}".format(
             name=u.get("displayName", ""),
-            email="&lt;{}&gt;".format(u["email"]) if "email" in u else ""
+            email="({})".format(u["email"]) if "email" in u and u["email"] != "" else ""
         ).strip()
     )
 


### PR DESCRIPTION
- Updates invitation html text as specified [here](https://github.com/ChildMindInstitute/mindlogger-app/issues/824) 
- Updates ```formatUserString``` to display emails with () instead of <>
- Preview of invitation when inviter has no email attached to his/her account:
![image](https://user-images.githubusercontent.com/31543235/77956672-e5d82f80-7297-11ea-9598-d06500a8ec23.png)
- 
Fixes https://github.com/ChildMindInstitute/mindlogger-app/issues/824