### PR TITLE
updating old event to new one was fixed

### DIFF
--- a/girderformindlogger/models/pushNotification.py
+++ b/girderformindlogger/models/pushNotification.py
@@ -146,6 +146,8 @@ class PushNotification(Model):
                 if start_time > current_user_date.strftime('%H:%M') \
                     and schedule['start'] >= current_user_date.strftime('%Y/%m/%d'):
                     push_notification.update({
+                        'dateSend': None,
+                        'lastRandomTime': None,
                         'progress': ProgressState.ACTIVE
                     })
             return self.save(push_notification)

--- a/girderformindlogger/models/pushNotification.py
+++ b/girderformindlogger/models/pushNotification.py
@@ -146,13 +146,13 @@ class PushNotification(Model):
                 if start_time > current_user_date.strftime('%H:%M') \
                     and schedule['start'] >= current_user_date.strftime('%Y/%m/%d'):
                     push_notification.update({
-                        'progress': ProgressState.ACTIVE
+                        'progress': ProgressState.ACTIVE,
+                        'lastRandomTime': None
                     })
 
                     if push_notification['notification_type'] == 1:
                         push_notification.update({
                             'dateSend': None,
-                            'lastRandomTime': None,
                         })
             return self.save(push_notification)
         return None

--- a/girderformindlogger/models/pushNotification.py
+++ b/girderformindlogger/models/pushNotification.py
@@ -146,10 +146,14 @@ class PushNotification(Model):
                 if start_time > current_user_date.strftime('%H:%M') \
                     and schedule['start'] >= current_user_date.strftime('%Y/%m/%d'):
                     push_notification.update({
-                        'dateSend': None,
-                        'lastRandomTime': None,
                         'progress': ProgressState.ACTIVE
                     })
+
+                    if push_notification['notification_type'] == 1:
+                        push_notification.update({
+                            'dateSend': None,
+                            'lastRandomTime': None,
+                        })
             return self.save(push_notification)
         return None
 


### PR DESCRIPTION
the process of updating the past time of old events to a new time, led to errors that they would not be sent in the future.
settings on the last fixed date have been reset