### PR TITLE
fix added for notifications after complete activity

### DIFF
--- a/girderformindlogger/external/notification.py
+++ b/girderformindlogger/external/notification.py
@@ -38,14 +38,16 @@ def send_push_notification(applet_id, event_id):
             query['individual_events'] = {'$gte': 1}
 
         if event['data']['notifications'][0]['notifyIfIncomplete']:
-            query['$or'] = [
+            query['$and'] = [
                 {
                     'completed_activities.completed_time': {
-                        '$lt': datetime.datetime.strptime(f"{now.year}/{now.month}/{now.day}",
-                                                          '%Y/%m/%d')}
+                        '$ne': None
+                    }
                 },
                 {
-                    'completed_activities.completed_time': {'$eq': None}
+                    'completed_activities.completed_time': {
+                        '$lt': now
+                    }
                 }
             ]
 


### PR DESCRIPTION
fix added for notifications after complete activity
[#1028](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-app/1028)