### PR TITLE
insert encryption info in applet metadata

### DIFF
--- a/girderformindlogger/api/v1/applet.py
+++ b/girderformindlogger/api/v1/applet.py
@@ -608,9 +608,15 @@ class Applet(Resource):
             ]),
             required=False
         )
+        .jsonParam(
+            'encryption',
+            'encryption info',
+            paramType='form',
+            required=False
+        )
         .errorResponse('Write access was denied for this applet.', 403)
     )
-    def createApplet(self, protocolUrl=None, email='', name=None, informant=None):
+    def createApplet(self, protocolUrl=None, email='', name=None, informant=None, encryption={}):
         accountProfile = AccountProfile()
 
         thisUser = self.getCurrentUser()
@@ -636,7 +642,8 @@ class Applet(Resource):
                     'informantRelationship': informant
                 } if informant is not None else None,
                 'appletRole': appletRole,
-                'accountId': profile['accountId']
+                'accountId': profile['accountId'],
+                'encryption': encryption
             }
         )
         thread.start()
@@ -711,9 +718,15 @@ class Applet(Resource):
             ]),
             required=False
         )
+        .jsonParam(
+            'encryption',
+            'encryption info',
+            paramType='form',
+            required=False
+        )
         .errorResponse('Write access was denied for this applet.', 403)
     )
-    def createAppletFromProtocolData(self, protocol, email='', name=None, informant=None):
+    def createAppletFromProtocolData(self, protocol, email='', name=None, informant=None, encryption={}):
         accountProfile = AccountProfile()
 
         thisUser = self.getCurrentUser()
@@ -739,7 +752,8 @@ class Applet(Resource):
                     'informantRelationship': informant
                 } if informant is not None else None,
                 'appletRole': appletRole,
-                'accountId': profile['accountId']
+                'accountId': profile['accountId'],
+                'encryption': encryption
             }
         )
         thread.start()

--- a/girderformindlogger/models/applet.py
+++ b/girderformindlogger/models/applet.py
@@ -57,7 +57,8 @@ class Applet(FolderModel):
         constraints=None,
         appletName=None,
         appletRole='editor',
-        accountId=None
+        accountId=None,
+        encryption={}
     ):
         """
         Method to create an Applet.
@@ -104,7 +105,8 @@ class Applet(FolderModel):
                 'applet': constraints if constraints is not None and isinstance(
                     constraints,
                     dict
-                ) else {}
+                ) else {},
+                'encryption': encryption
             }
         )
 
@@ -438,7 +440,8 @@ class Applet(FolderModel):
         email='',
         sendEmail=True,
         appletRole='editor',
-        accountId=None
+        accountId=None,
+        encryption={}
     ):
         from girderformindlogger.models.protocol import Protocol
         from girderformindlogger.utility import mail_utils
@@ -493,7 +496,8 @@ class Applet(FolderModel):
                 constraints=constraints,
                 appletName=appletName,
                 appletRole=appletRole,
-                accountId=accountId
+                accountId=accountId,
+                encryption=encryption
             )
 
             emailMessage = "Hi {}.  <br>" \
@@ -530,7 +534,8 @@ class Applet(FolderModel):
         email='',
         sendEmail=True,
         appletRole='editor',
-        accountId=None
+        accountId=None,
+        encryption={}
     ):
         from girderformindlogger.models.protocol import Protocol
         from girderformindlogger.utility import mail_utils

--- a/girderformindlogger/utility/jsonld_expander.py
+++ b/girderformindlogger/utility/jsonld_expander.py
@@ -1111,6 +1111,7 @@ def formatLdObject(
             applet['applet'] = {
                 **protocol.pop('protocol', {}),
                 **obj.get('meta', {}).get(mesoPrefix, {}),
+                'encryption': obj.get('meta', {}).get('encryption', {}),
                 '_id': "/".join([snake_case(mesoPrefix), objID]),
                 'url': "#".join([
                     obj.get('meta', {}).get('protocol', {}).get("url", "")


### PR DESCRIPTION
# Resolves  [842](https://github.com/ChildMindInstitute/mindlogger-backend/issues/842)

# update create applet endpoint to accept public key and prime which will be used for response encryption/decryption
