### PR TITLE
fix applet naming issue for applets uploaded by protocol-builder

### DIFF
--- a/girderformindlogger/utility/jsonld_expander.py
+++ b/girderformindlogger/utility/jsonld_expander.py
@@ -1130,9 +1130,6 @@ def formatLdObject(
                             if len(suffix):
                                 applet['applet'][key][0]['@value'] += (' ' + suffix)
 
-                            if not len(applet['applet']['url']): # for development
-                                applet['applet'][key][0]['@value'] += ' ( single-file )'
-
                             AppletModel().update({'_id': obj['_id']}, {'$set': {'displayName': applet['applet'][key][0]['@value']}})
 
                             inserted = True


### PR DESCRIPTION
# Resolves [19](https://github.com/ChildMindInstitute/mindlogger-applet-builder/issues/19)

# fix applet naming issue

# old applet names won't change, and this fix will be applied to new applets created using protocol-builder.
