### PR TITLE
Fixed the notifications are fired on the device after turning off the notification settings

### DIFF
--- a/girderformindlogger/models/events.py
+++ b/girderformindlogger/models/events.py
@@ -150,10 +150,11 @@ class Events(Model):
         return events
 
     def setSchedule(self, event):
+        push_notification = PushNotificationModel(event=event)
+        push_notification.remove_schedules()
         if 'data' in event and 'useNotifications' in event['data'] and event['data'][
             'useNotifications']:
             if 'notifications' in event['data'] and event['data']['notifications'][0]['start']:
-                push_notification = PushNotificationModel(event=event)
                 push_notification.set_schedules()
 
     def getSchedule(self, applet_id):
@@ -189,8 +190,8 @@ class Events(Model):
 
         if eventTimeout and eventTimeout.get('allow', False) and event['data'].get('completion', False):
             timeout = datetime.timedelta(
-                days=eventTimeout.get('day', 0), 
-                hours=eventTimeout.get('hour', 0), 
+                days=eventTimeout.get('day', 0),
+                hours=eventTimeout.get('hour', 0),
                 minutes=eventTimeout.get('minute', 0)
             )
 


### PR DESCRIPTION
**Resolves** [1205](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-app/1205)

The notifications are fired on the device after turning off the notification settings and resaving the schedule on the 'Admin Panel was fixed in event model